### PR TITLE
More universal host and port

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,8 +23,8 @@ module.exports = {
   plugins: [
     definePlugin,
     new BrowserSyncPlugin({
-      host: 'localhost',
-      port: 3000,
+      host: process.env.IP || 'localhost',
+      port: process.env.PORT || 3000,
       open: false,
       server: {
         baseDir: ['./', './build']


### PR DESCRIPTION
For example, it allows using your boilerplate in cloud9
