### PR TITLE
Don't install webpack globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,6 @@ Navigate to the cloned repo’s directory.
 
 Run:
 
-```npm install webpack -g```
-
-and
-
 ```npm install```
 
 ## 4. Run the development server:


### PR DESCRIPTION
Hello,

Since you are using npm scripts and webpack is listed in devDependencies, there is no need in global install.

npm adds installed binaries to PATH automatically:

> In addition to the shell's pre-existing PATH, npm run adds node_modules/.bin to the PATH provided to scripts. 
> https://docs.npmjs.com/cli/run-script
