### PR TITLE
Fix by standard

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = {
   watch: true,
   plugins: [
     definePlugin,
-    new webpack.optimize.CommonsChunkPlugin(/* chunkName= */"vendor", /* filename= */"vendor.bundle.js"),
+    new webpack.optimize.CommonsChunkPlugin(/* chunkName= */'vendor', /* filename= */'vendor.bundle.js'),
     new BrowserSyncPlugin({
       host: process.env.IP || 'localhost',
       port: process.env.PORT || 3000,

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -40,7 +40,7 @@ module.exports = {
     }),
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.optimize.DedupePlugin(),
-    new webpack.optimize.CommonsChunkPlugin(/* chunkName= */"vendor", /* filename= */"vendor.bundle.js"),    
+    new webpack.optimize.CommonsChunkPlugin(/* chunkName= */'vendor', /* filename= */'vendor.bundle.js')
   ],
   module: {
     loaders: [


### PR DESCRIPTION
Execute
$(npm bin)/standard --fix

Before:

```
$ npm test

> PhaserES6Webpack@1.0.0 test /mnt/623D90F735FA5D47/sanemat/data/src/github.com/lean/phaser-es6-webpack
> standard

standard: Use JavaScript Standard Style (http://standardjs.com)
standard: Run `standard --fix` to automatically fix some problems.
  /mnt/623D90F735FA5D47/sanemat/data/src/github.com/lean/phaser-es6-webpack/webpack.config.js:33:61: Strings must u
se singlequote.
  /mnt/623D90F735FA5D47/sanemat/data/src/github.com/lean/phaser-es6-webpack/webpack.config.js:33:86: Strings must u
se singlequote.
  /mnt/623D90F735FA5D47/sanemat/data/src/github.com/lean/phaser-es6-webpack/webpack.production.config.js:43:61: Str
ings must use singlequote.
  /mnt/623D90F735FA5D47/sanemat/data/src/github.com/lean/phaser-es6-webpack/webpack.production.config.js:43:86: Str
ings must use singlequote.
  /mnt/623D90F735FA5D47/sanemat/data/src/github.com/lean/phaser-es6-webpack/webpack.production.config.js:43:105: Un
expected trailing comma.
  /mnt/623D90F735FA5D47/sanemat/data/src/github.com/lean/phaser-es6-webpack/webpack.production.config.js:43:106: Tr
ailing spaces not allowed.
npm ERR! Test failed.  See above for more details.
```

After:

```
$ npm test

> PhaserES6Webpack@1.0.0 test /mnt/623D90F735FA5D47/sanemat/data/src/github.com/lean/phaser-es6-webpack
> standard
```