### PR TITLE
fixed issue in Game.js with the Banner creation throwing an exception

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "PhaserES6Webpack",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "",
     "author": "leandro cabrera <leandcabrera@gmail.com>",
     "main": "index.js",

--- a/src/states/Game.js
+++ b/src/states/Game.js
@@ -8,12 +8,13 @@ export default class extends Phaser.State {
 
   create () {
     const bannerText = 'Phaser + ES6 + Webpack'
-    let banner = this.add.text(this.world.centerX, this.game.height - 80, bannerText)
-    banner.font = 'Bangers'
+    let banner = this.add.text(this.world.centerX, this.game.height - 80, bannerText, {
+      font: '40px Bangers',
+      fill: '#77BFA3',
+      smoothed: false
+    })
+
     banner.padding.set(10, 16)
-    banner.fontSize = 40
-    banner.fill = '#77BFA3'
-    banner.smoothed = false
     banner.anchor.setTo(0.5)
 
     this.mushroom = new Mushroom({


### PR DESCRIPTION
I checked this project out a few days ago and using node `8.8` with npm `5.5.1` I received the following error.

## Before PR with default build `npm i && npm run dev`
![screen shot 2017-12-17 at 12 06 27 pm](https://user-images.githubusercontent.com/1403700/34081963-075bddc4-e324-11e7-840d-49669cd8ad71.png)


The included PR fixes this issue and makes the boilerplate es6 + webpack application work as intended.

## After PR with default build `npm i && npm run dev`
![screen shot 2017-12-17 at 12 09 51 pm](https://user-images.githubusercontent.com/1403700/34081973-2511a092-e324-11e7-95dd-cd047a6d79e2.png)

