### PR TITLE
Fix bad linter usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "dev": "webpack",
         "deploy": "webpack --config webpack.production.config.js",
         "cordova": "webpack --config webpack.cordova.config.js",
-        "test": "eslint ./src/**/**.js"
+        "test": "eslint './src/**/*.js'"
     },
     "license": "MIT",
     "devDependencies": {


### PR DESCRIPTION
Errors were not detected. You can test the case by adding an extra semicolon in the `main.js` for example.