### PR TITLE
Deploy production build to separate build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .vscode/
 *.log
 /index.html
+build/

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -2,6 +2,7 @@ var path = require('path')
 var webpack = require('webpack')
 var CleanWebpackPlugin = require('clean-webpack-plugin')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
+var CopyWebpackPlugin = require('copy-webpack-plugin')
 
 // Phaser webpack config
 var phaserModule = path.join(__dirname, '/node_modules/phaser-ce/')
@@ -23,13 +24,13 @@ module.exports = {
 
   },
   output: {
-    path: path.resolve(__dirname, 'dist'),
-    publicPath: './dist/',
-    filename: 'bundle.js'
+    path: path.resolve(__dirname, 'build'),
+    publicPath: './',
+    filename: 'js/bundle.js'
   },
   plugins: [
     definePlugin,
-    new CleanWebpackPlugin(['dist']),
+    new CleanWebpackPlugin(['build']),
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     new webpack.optimize.UglifyJsPlugin({
       drop_console: true,
@@ -38,9 +39,9 @@ module.exports = {
         comments: false
       }
     }),
-    new webpack.optimize.CommonsChunkPlugin({ name: 'vendor'/* chunkName= */, filename: 'vendor.bundle.js'/* filename= */}),
+    new webpack.optimize.CommonsChunkPlugin({ name: 'vendor' /* chunkName= */ , filename: 'js/vendor.bundle.js' /* filename= */ }),
     new HtmlWebpackPlugin({
-      filename: '../index.html',
+      filename: 'index.html', // path.resolve(__dirname, 'build', 'index.html'),
       template: './src/index.html',
       chunks: ['vendor', 'app'],
       chunksSortMode: 'manual',
@@ -55,7 +56,10 @@ module.exports = {
         removeEmptyAttributes: true
       },
       hash: true
-    })
+    }),
+    new CopyWebpackPlugin([
+      { from: 'assets', to: 'assets' }
+    ])
   ],
   module: {
     rules: [


### PR DESCRIPTION
This change amends the webpack production config, so instead of merging with the root folder, it is deployed to a separate "build" folder. The assets are also copied into this folder. The built javascript files are put into a subfolder "js" for cleanliness.

I have made this change to easily support firebase hosting.