### PR TITLE
Fixed completions for VS Code

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,6 @@
     "phaser": true
   },
   "settings": {
-    "import/core-modules": ["phaser", "pixi", "p2"]
+    "import/core-modules": ["phaser-ce", "pixi", "p2"]
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import 'pixi'
 import 'p2'
-import Phaser from 'phaser'
+import Phaser from 'phaser-ce'
 
 import BootState from './states/Boot'
 import SplashState from './states/Splash'

--- a/src/sprites/Mushroom.js
+++ b/src/sprites/Mushroom.js
@@ -1,4 +1,4 @@
-import Phaser from 'phaser'
+import Phaser from 'phaser-ce'
 
 export default class extends Phaser.Sprite {
   constructor ({ game, x, y, asset }) {

--- a/src/states/Boot.js
+++ b/src/states/Boot.js
@@ -1,4 +1,4 @@
-import Phaser from 'phaser'
+import Phaser from 'phaser-ce'
 import WebFont from 'webfontloader'
 
 export default class extends Phaser.State {

--- a/src/states/Game.js
+++ b/src/states/Game.js
@@ -1,5 +1,5 @@
 /* globals __DEV__ */
-import Phaser from 'phaser'
+import Phaser from 'phaser-ce'
 import Mushroom from '../sprites/Mushroom'
 
 export default class extends Phaser.State {

--- a/src/states/Splash.js
+++ b/src/states/Splash.js
@@ -1,4 +1,4 @@
-import Phaser from 'phaser'
+import Phaser from 'phaser-ce'
 import { centerGameObjects } from '../utils'
 
 export default class extends Phaser.State {


### PR DESCRIPTION
Not entirely sure if this breaks things in other environments, but by importing using 'phaser-ce' instead of 'phaser' (which isn't a dependency) code completion/intellisense works in VS Code now without further jiggering.